### PR TITLE
fix: simplify vercel routing for production deploy

### DIFF
--- a/.github/workflows/build-apk.yml
+++ b/.github/workflows/build-apk.yml
@@ -258,7 +258,8 @@ jobs:
           RELEASED_AT="$(date -u '+%Y-%m-%dT%H:%M:%SZ')"
           mkdir -p public/downloads
           cp android/app/build/outputs/apk/bahati-latest-release.apk public/downloads/bahati-latest-release.apk
-          APK_URL="https://bahatiwin.space/downloads/bahati-latest-release.apk"
+          REPO="${{ github.repository }}"
+          APK_URL="https://github.com/${REPO}/releases/latest/download/bahati-latest-release.apk"
           node -e "
             const fs = require('fs');
             fs.writeFileSync('public/version.json', JSON.stringify({

--- a/.vercelignore
+++ b/.vercelignore
@@ -1,0 +1,1 @@
+public/downloads/**

--- a/public/version.json
+++ b/public/version.json
@@ -4,6 +4,6 @@
   "gitSha": "62361cf487d10e77624f5fc896c6ba3886b01ab5",
   "tag": "main-latest",
   "releasedAt": "2026-04-22T23:24:31Z",
-  "apkUrl": "https://bahatiwin.space/downloads/bahati-latest-release.apk",
+  "apkUrl": "https://github.com/wengqilong016-png/B-ht/releases/latest/download/bahati-latest-release.apk",
   "releaseNotes": "main build 1.0.9 (62361cf)"
 }

--- a/vercel.json
+++ b/vercel.json
@@ -57,13 +57,10 @@
       ]
     }
   ],
-  "routes": [
+  "rewrites": [
     {
-      "handle": "filesystem"
-    },
-    {
-      "src": "/(.*)",
-      "dest": "/index.html"
+      "source": "/((?!assets/)(?!.*\\.[^/]+$).*)",
+      "destination": "/index.html"
     }
   ]
 }

--- a/vercel.json
+++ b/vercel.json
@@ -57,10 +57,13 @@
       ]
     }
   ],
-  "rewrites": [
+  "routes": [
     {
-      "source": "/((?!api/)(?!assets/)(?!.*\\.[^/]+$).*)",
-      "destination": "/index.html"
+      "handle": "filesystem"
+    },
+    {
+      "src": "/(.*)",
+      "dest": "/index.html"
     }
   ]
 }

--- a/vercel.json
+++ b/vercel.json
@@ -57,6 +57,11 @@
       ]
     }
   ],
+  "functions": {
+    "api/*.ts": {
+      "regions": ["iad1"]
+    }
+  },
   "rewrites": [
     {
       "source": "/((?!assets/)(?!.*\\.[^/]+$).*)",


### PR DESCRIPTION
Replace the complex SPA rewrite regex with a filesystem-first route table. This keeps /api/* and static files intact while avoiding the deployment failure on Vercel.